### PR TITLE
feat: add new project prototype

### DIFF
--- a/client/src/components/Nav/Nav.tsx
+++ b/client/src/components/Nav/Nav.tsx
@@ -16,6 +16,7 @@ import { Conversations } from '~/components/Conversations';
 import SearchBar from './SearchBar';
 import NewChat from './NewChat';
 import { cn } from '~/utils';
+import NewProject from './NewProject';
 import store from '~/store';
 
 const BookmarkNav = lazy(() => import('./Bookmarks/BookmarkNav'));
@@ -158,6 +159,7 @@ const Nav = memo(
     const headerButtons = useMemo(
       () => (
         <>
+          <NewProject toggleNav={toggleNavVisible} isSmallScreen={isSmallScreen} />
           <Suspense fallback={null}>
             <AgentMarketplaceButton isSmallScreen={isSmallScreen} toggleNav={toggleNavVisible} />
           </Suspense>

--- a/client/src/components/Nav/NewProject.tsx
+++ b/client/src/components/Nav/NewProject.tsx
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { TooltipAnchor, Button } from '@librechat/client';
+import { FolderPlus } from 'lucide-react';
+import { useLocalize } from '~/hooks';
+
+export default function NewProject({
+  toggleNav,
+  isSmallScreen,
+}: {
+  toggleNav: () => void;
+  isSmallScreen?: boolean;
+}) {
+  const navigate = useNavigate();
+  const localize = useLocalize();
+
+  const clickHandler = useCallback(() => {
+    navigate('/projects/new/c/new');
+    if (isSmallScreen) {
+      toggleNav();
+    }
+  }, [navigate, isSmallScreen, toggleNav]);
+
+  return (
+    <TooltipAnchor
+      description={localize('com_ui_new_project')}
+      render={
+        <Button
+          size="icon"
+          variant="outline"
+          aria-label={localize('com_ui_new_project')}
+          className="rounded-full border-none bg-transparent p-2 hover:bg-surface-hover md:rounded-xl"
+          onClick={clickHandler}
+        >
+          <FolderPlus className="icon-lg text-text-primary" />
+        </Button>
+      }
+    />
+  );
+}

--- a/client/src/routes/ProjectRoute.tsx
+++ b/client/src/routes/ProjectRoute.tsx
@@ -1,0 +1,26 @@
+import ChatRoute from './ChatRoute';
+import DragDropWrapper from '~/components/Chat/Input/Files/DragDropWrapper';
+import { useLocalize } from '~/hooks';
+
+export default function ProjectRoute() {
+  const localize = useLocalize();
+
+  return (
+    <div className="flex h-full w-full">
+      <div className="flex flex-1 flex-col">
+        <ChatRoute />
+      </div>
+      <aside className="border-border-subtle flex w-80 flex-col gap-4 border-l p-4">
+        <DragDropWrapper className="border-border-subtle flex flex-1 items-center justify-center rounded-md border border-dashed">
+          <p className="text-sm text-text-secondary">{localize('com_ui_drag_drop')}</p>
+        </DragDropWrapper>
+        <div className="flex-1 overflow-y-auto">
+          <h3 className="mb-2 text-sm font-medium">{localize('com_ui_past_chats')}</h3>
+          <ul className="space-y-2 text-sm text-text-secondary">
+            <li>{localize('com_ui_no_chats_yet')}</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -17,6 +17,7 @@ import LoginLayout from './Layouts/Login';
 import dashboardRoutes from './Dashboard';
 import ShareRoute from './ShareRoute';
 import ChatRoute from './ChatRoute';
+import ProjectRoute from './ProjectRoute';
 import Search from './Search';
 import Root from './Root';
 
@@ -113,6 +114,10 @@ export const router = createBrowserRouter([
           {
             path: 'agents/:category',
             element: <AgentMarketplace />,
+          },
+          {
+            path: 'projects/:projectId/c/:conversationId?',
+            element: <ProjectRoute />,
           },
         ],
       },


### PR DESCRIPTION
## Summary
- add `+ New Project` button to sidebar
- prototype project page with chat view, file drop area, and past chats section
- wire new project route

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*
- `npx eslint client/src/components/Nav/NewProject.tsx client/src/components/Nav/Nav.tsx client/src/routes/ProjectRoute.tsx client/src/routes/index.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68ac5bb70ba48326b5003935467155ef