### PR TITLE
fix: show KB name on creation

### DIFF
--- a/client/src/components/Chat/Header.tsx
+++ b/client/src/components/Chat/Header.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useMediaQuery } from '@librechat/client';
-import { useOutletContext, useParams } from 'react-router-dom';
+import { useOutletContext, useParams, useLocation } from 'react-router-dom';
 import { getConfigDefaults, PermissionTypes, Permissions } from 'librechat-data-provider';
 import type { ContextType } from '~/common';
 import ModelSelector from './Menus/Endpoints/ModelSelector';
@@ -18,12 +18,16 @@ export default function Header() {
   const { data: startupConfig } = useGetStartupConfig();
   const { navVisible, setNavVisible } = useOutletContext<ContextType>();
   const { kbId } = useParams();
+  const location = useLocation();
+  const kbNameFromState = (location.state as { kbName?: string } | null)?.kbName;
 
   const { data: knowledgeBasesData } = useKnowledgeBasesQuery();
   const activeKB = useMemo(() => {
     if (!knowledgeBasesData || !kbId) return null;
     return knowledgeBasesData.find((kb) => kb.id === kbId || kb.name === kbId) || null;
   }, [knowledgeBasesData, kbId]);
+
+  const displayName = activeKB?.name || kbNameFromState;
 
   const interfaceConfig = useMemo(
     () => startupConfig?.interface ?? defaultInterface,
@@ -75,7 +79,7 @@ export default function Header() {
                 <TemporaryChat />
               </>
             )}
-            {kbId && `You are chatting with ${activeKB.name}`}
+            {kbId && displayName && `You are chatting with ${displayName}`}
           </div>
         </div>
         {!isSmallScreen && (

--- a/client/src/components/Nav/NewKnowledgeBase.tsx
+++ b/client/src/components/Nav/NewKnowledgeBase.tsx
@@ -36,11 +36,13 @@ export default function NewKnowledgeBase({
       return;
     }
     try {
-      const kb = await dataService.createKnowledgeBase({name: trimmed});
+      const kb = await dataService.createKnowledgeBase({ name: trimmed });
       const displayId = kb.slug || kb._id || trimmed;
       const displayName = kb.name || trimmed;
       queryClient.invalidateQueries([QueryKeys.knowledgeBases]);
-      navigate(`/knowledge-bases/${encodeURIComponent(displayId)}/c/new`);
+      navigate(`/knowledge-bases/${encodeURIComponent(displayId)}/c/new`, {
+        state: { kbName: displayName },
+      });
     } catch (_e) {
       showToast({ message: localize('com_ui_kb_error'), status: 'error' })
     }

--- a/client/src/routes/KnowledgeBaseRoute.tsx
+++ b/client/src/routes/KnowledgeBaseRoute.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useLocation } from 'react-router-dom';
 import { Files } from 'lucide-react';
 import ChatRoute from './ChatRoute';
 import DragDropWrapper from '~/components/Chat/Input/Files/DragDropWrapper';
@@ -8,6 +8,8 @@ import { useKnowledgeBaseConversationsQuery, useKnowledgeBasesQuery } from '~/da
 export default function KnowledgeBaseRoute({}: KnowledgeBaseRouteProps = {}) {
   const localize = useLocalize();
   const { kbId = '', conversationId = null } = useParams();
+  const location = useLocation();
+  const kbNameFromState = (location.state as { kbName?: string } | null)?.kbName;
   const [files] = useState([]);
   const { data, isLoading, isError, fetchNextPage, hasNextPage } =
     useKnowledgeBaseConversationsQuery(kbId, { limit: 20 });
@@ -19,6 +21,8 @@ export default function KnowledgeBaseRoute({}: KnowledgeBaseRouteProps = {}) {
     return knowledgeBasesData.find((kb) => kb.id === kbId || kb.name === kbId) || null;
   }, [knowledgeBasesData, kbId]);
 
+  const displayName = activeKB?.name || kbNameFromState || '';
+
   return (
     <div className="flex h-full w-full flex-col">
       {conversationId ? (
@@ -28,7 +32,7 @@ export default function KnowledgeBaseRoute({}: KnowledgeBaseRouteProps = {}) {
       ) : (
         <div className="flex flex-1 flex-col">
           <h1>HumaRAG</h1>
-          <p>Welcome to your collection: {activeKB.name}</p>
+          {displayName && <p>Welcome to your collection: {displayName}</p>}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- pass knowledge base name to new chat route on creation
- display passed name in knowledge base route and chat header until API data loads

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*


------
https://chatgpt.com/codex/tasks/task_b_68bfcd5fe5b88326849396dcab141e2d