### PR TITLE
feat: add knowledge base selection landing page

### DIFF
--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -997,6 +997,8 @@
   "com_ui_kb_error": "Failed to create the Knowledge Base, please try again.",
   "com_ui_past_chats": "Knowledge base past chats",
   "com_ui_no_chats_yet": "You haven't got any conversations within this knowledge base yet.",
+  "com_ui_select_kb": "Select a Knowledge Base",
+  "com_ui_no_kbs": "You don't have any knowledge bases yet.",
   "com_ui_next": "Next",
   "com_ui_no": "No",
   "com_ui_no_bookmarks": "it seems like you have no bookmarks yet. Click on a chat and add a new one",

--- a/client/src/routes/KnowledgeBasesSelectorRoute.test.tsx
+++ b/client/src/routes/KnowledgeBasesSelectorRoute.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import KnowledgeBasesSelectorRoute from './KnowledgeBasesSelectorRoute';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('~/data-provider', () => ({
+  useKnowledgeBasesQuery: () => ({ data: [{ id: '1', name: 'KB1' }], isLoading: false }),
+  dataService: { createKnowledgeBase: jest.fn().mockResolvedValue({ _id: '2', name: 'KB2' }) },
+  QueryKeys: { knowledgeBases: 'knowledgeBases' },
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+
+jest.mock(
+  '@librechat/client',
+  () => ({
+    Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+    OGDialog: ({ open, children }) => (open ? <div>{children}</div> : null),
+    OGDialogTemplate: ({ title, main, buttons }) => (
+      <div>
+        <div>{title}</div>
+        <div>{main}</div>
+        <div>{buttons}</div>
+      </div>
+    ),
+    Input: (props) => <input {...props} />,
+    Label: (props) => <label {...props} />,
+    useToastContext: () => ({ showToast: jest.fn() }),
+  }),
+  { virtual: true },
+);
+
+jest.mock('lucide-react', () => ({
+  Plus: () => <div>plus</div>,
+  Folder: () => <div>folder</div>,
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => {
+    const map: Record<string, string> = {
+      com_ui_select_kb: 'Select KB',
+      com_ui_no_kbs: 'No KBs',
+      com_ui_new_knowledge_base: 'Create KB',
+      com_ui_name: 'Name',
+      com_ui_create: 'Create',
+    };
+    return map[key] || key;
+  },
+}));
+
+test('renders knowledge base list and create button', () => {
+  render(<KnowledgeBasesSelectorRoute />);
+  expect(screen.getByText('Select KB')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /KB1/ })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Create KB/ })).toBeInTheDocument();
+});
+

--- a/client/src/routes/KnowledgeBasesSelectorRoute.tsx
+++ b/client/src/routes/KnowledgeBasesSelectorRoute.tsx
@@ -1,0 +1,111 @@
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Plus, Folder } from 'lucide-react';
+import {
+  Button,
+  OGDialog,
+  OGDialogTemplate,
+  Input,
+  Label,
+  useToastContext,
+} from '@librechat/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { useKnowledgeBasesQuery, dataService, QueryKeys } from '~/data-provider';
+import { useLocalize } from '~/hooks';
+
+export default function KnowledgeBasesSelectorRoute() {
+  const navigate = useNavigate();
+  const localize = useLocalize();
+  const { data: knowledgeBases = [] } = useKnowledgeBasesQuery();
+
+  const handleSelect = (kb: any) => {
+    const displayId = kb.slug || kb.id || kb._id || kb.name;
+    navigate(`/knowledge-bases/${encodeURIComponent(displayId)}/c/new`);
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-4">
+      <h1 className="text-2xl font-semibold">{localize('com_ui_select_kb')}</h1>
+      {knowledgeBases.length > 0 ? (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+          {knowledgeBases.map((kb) => (
+            <Button
+              key={kb.id || kb._id || kb.name}
+              variant="outline"
+              className="h-40 w-40 flex flex-col items-center justify-center gap-2"
+              onClick={() => handleSelect(kb)}
+            >
+              <Folder className="h-12 w-12" />
+              <span className="text-lg">{kb.name}</span>
+            </Button>
+          ))}
+          <CreateKnowledgeBaseCard />
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-4">
+          <p className="text-text-secondary">{localize('com_ui_no_kbs')}</p>
+          <CreateKnowledgeBaseCard />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CreateKnowledgeBaseCard() {
+  const localize = useLocalize();
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const { showToast } = useToastContext();
+  const queryClient = useQueryClient();
+
+  const createKnowledgeBase = useCallback(async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return;
+    }
+    try {
+      const kb = await dataService.createKnowledgeBase({ name: trimmed });
+      const displayId = kb.slug || kb._id || trimmed;
+      queryClient.invalidateQueries([QueryKeys.knowledgeBases]);
+      navigate(`/knowledge-bases/${encodeURIComponent(displayId)}/c/new`);
+    } catch (_e) {
+      showToast({ message: localize('com_ui_kb_error'), status: 'error' });
+    }
+    setOpen(false);
+    setName('');
+  }, [name, navigate, queryClient, showToast, localize]);
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        className="h-40 w-40 flex flex-col items-center justify-center gap-2"
+        onClick={() => setOpen(true)}
+      >
+        <Plus className="h-12 w-12" />
+        <span className="text-lg">{localize('com_ui_new_knowledge_base')}</span>
+      </Button>
+      <OGDialog open={open} onOpenChange={setOpen}>
+        <OGDialogTemplate
+          title={localize('com_ui_new_knowledge_base')}
+          main={
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="kb-name" className="text-left text-sm font-medium">
+                {localize('com_ui_name')}
+              </Label>
+              <Input
+                id="kb-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={localize('com_ui_new_knowledge_base')}
+              />
+            </div>
+          }
+          buttons={<Button onClick={createKnowledgeBase}>{localize('com_ui_create')}</Button>}
+        />
+      </OGDialog>
+    </>
+  );
+}
+

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
+import { createBrowserRouter, Outlet } from 'react-router-dom';
 import {
   Login,
   VerifyEmail,
@@ -18,6 +18,7 @@ import dashboardRoutes from './Dashboard';
 import ShareRoute from './ShareRoute';
 import ChatRoute from './ChatRoute';
 import KnowledgeBaseRoute from './KnowledgeBaseRoute';
+import KnowledgeBasesSelectorRoute from './KnowledgeBasesSelectorRoute';
 import Search from './Search';
 import Root from './Root';
 
@@ -97,7 +98,7 @@ export const router = createBrowserRouter([
         children: [
           {
             index: true,
-            element: <Navigate to="/c/new" replace={true} />,
+            element: <KnowledgeBasesSelectorRoute />,
           },
           {
             path: 'c/:conversationId?',
@@ -114,6 +115,10 @@ export const router = createBrowserRouter([
           {
             path: 'agents/:category',
             element: <AgentMarketplace />,
+          },
+          {
+            path: 'knowledge-bases',
+            element: <KnowledgeBasesSelectorRoute />,
           },
           {
             path: 'knowledge-bases/:kbId',


### PR DESCRIPTION
## Summary
- rename KnowledgeBasesRoute to KnowledgeBasesSelectorRoute for clarity
- keep knowledge base selector as default route and at `/knowledge-bases`
- localized strings support knowledge base selection and empty state

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68bfcd2db99c832682a4453b0038bb2e